### PR TITLE
Added api key and engine setting in local storage

### DIFF
--- a/client/src/components/modals/settings-modal.tsx
+++ b/client/src/components/modals/settings-modal.tsx
@@ -107,7 +107,7 @@ export default function SettingsModal() {
                 if (config) {
                   setApiKey(config.apiKey); // Update API key input when engine changes
                 } else {
-                  setApiKey(""); // Clear API key if no config found
+                  //setApiKey(""); // Clear API key if no config found
                 }
               }}
             >

--- a/client/src/components/modals/settings-modal.tsx
+++ b/client/src/components/modals/settings-modal.tsx
@@ -61,6 +61,8 @@ export default function SettingsModal() {
       setConfigurations([...configurations, newConfig]);
     }
 
+    // Save to local storage
+    localStorage.setItem("chatbotConfigurations", JSON.stringify(configurations));
     setCurrentConfig(newConfig);
   };
 

--- a/client/src/contexts/settings-context.tsx
+++ b/client/src/contexts/settings-context.tsx
@@ -1,5 +1,11 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { ThemeProvider } from "next-themes";
+
+interface EngineConfig {
+  engine: string;
+  apiKey: string;
+}
+
 interface SettingsContextProps {
   fontSize: "small" | "medium" | "large";
   setFontSize: (size: "small" | "medium" | "large") => void;
@@ -30,19 +36,15 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
       | "medium"
       | "large";
 
-    const savedConfigs = localStorage.getItem("configurations");
+    const savedConfigs = localStorage.getItem("chatbotConfigurations");
     if (savedConfigs) {
       try {
-        const parsedConfigs = JSON.parse(savedConfigs);
-
-        setCurrentConfig(parsedConfigs[0]);
-        // Optionally, you can check if parsedConfigs is an array or object
-        if (Array.isArray(parsedConfigs) || typeof parsedConfigs === "object") {
+        const parsedConfigs: EngineConfig[] = JSON.parse(savedConfigs);
+        if (Array.isArray(parsedConfigs)) {
           setConfigurations(parsedConfigs);
+          setCurrentConfig(parsedConfigs.length > 0 ? parsedConfigs[0] : null);
         } else {
-          console.error(
-            "Parsed configuration is not valid. Expected an array or object."
-          );
+          console.error("Parsed configuration is not valid. Expected an array or object.");
         }
       } catch (error) {
         console.error("Failed to parse savedConfigs:", error);
@@ -59,7 +61,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const saveConfigurations = (configs: EngineConfig[]) => {
     setConfigurations(configs);
-    localStorage.setItem("configurations", JSON.stringify(configs));
+    localStorage.setItem("chatbotConfigurations", JSON.stringify(configs));
   };
 
   const themes = [


### PR DESCRIPTION
Closes #220 
---

### Description
- Implemented persistent storage for font size and chatbot configurations using localStorage
- Enhanced the initialization logic to ensure that configurations are correctly parsed and validated before setting them in state

### How Has This Been Tested?
--- Locally

### Screenshots (if applicable)

https://github.com/user-attachments/assets/66c70b6a-acfd-4203-bb19-686a115039c4


---

### Type of Change
<!-- Check the type of change this PR introduces -->
- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update
